### PR TITLE
Feature/docker log message

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       context: ./auth-api
     container_name: auth-api
     ports:
-      - "8080:8080"
+      - "8000:8000"
     depends_on:
       - users-api
       - zipkin
@@ -51,3 +51,6 @@ services:
       - todos-api
       - zipkin
 
+networks:
+  app-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,16 @@ services:
     container_name: redis-todo
     ports:
       - "6379:6379"
+    networks:
+      - app-network
 
   zipkin:
     image: openzipkin/zipkin:latest
     container_name: zipkin
     ports:
       - "9411:9411"
+    networks:
+      - app-network
 
   users-api:
     build:
@@ -20,6 +24,8 @@ services:
       - "8083:8083"
     depends_on:
       - zipkin
+    networks:
+      - app-network
 
   auth-api:
     build:
@@ -30,6 +36,8 @@ services:
     depends_on:
       - users-api
       - zipkin
+    networks:
+      - app-network
 
   todos-api:
     build:
@@ -40,6 +48,14 @@ services:
     depends_on: 
       - redis-todo
       - zipkin
+    networks:
+      - app-network
+    environment:
+      - REDIS_HOST=redis-todo
+      - REDIS_PORT=6379
+      - REDIS_CHANNEL=log_channel
+      - ZIPKIN_URL=http://zipkin:9411/api/v2/spans
+
   frontend:
     build:
       context: ./frontend
@@ -50,6 +66,24 @@ services:
       - auth-api
       - todos-api
       - zipkin
+    networks:
+      - app-network
+
+  log-message-processor:
+    build:
+      context: ./log-message-processor
+    container_name: log-message-processor
+    depends_on:
+      - redis-todo
+      - zipkin
+    environment:
+      - REDIS_HOST=redis-todo
+      - REDIS_PORT=6379
+      - REDIS_CHANNEL=log_channel
+      - ZIPKIN_URL=http://zipkin:9411/api/v2/spans
+      - PYTHONUNBUFFERED=1
+    networks:
+      - app-network
 
 networks:
   app-network:

--- a/e up -d --build
+++ b/e up -d --build
@@ -1,0 +1,3 @@
+* [32mdevelop[m
+  feature/Docker[m
+  master[m

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,21 +1,21 @@
-FROM node:8.17.0
+# Etapa 1: construir la app con Node 8
+FROM node:8.17.0 AS build
 WORKDIR /app
 
-# Variables de entorno para que Vue dev-server las use
-ENV HOST=0.0.0.0
-ENV PORT=3000
-ENV AUTH_API_ADDRESS=http://auth-api:8080
-ENV TODOS_API_ADDRESS=http://todos-api:8082
-ENV ZIPKIN_URL=http://zipkin:9411/api/v2/spans
-
-# Instalar dependencias
 COPY package*.json ./
 RUN npm install
 
-# Copiar el resto del código
 COPY . .
+RUN npm run build
+
+# Etapa 2: servir con Nginx
+FROM nginx:alpine
+
+# Copiar el build generado
+COPY --from=build /app/dist /usr/share/nginx/html
+
+# Copiar la configuración de Nginx
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 3000
-
-# Iniciar el servidor respetando las variables
-CMD ["npm", "start"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,30 @@
+server {
+    listen 3000;
+
+    server_name localhost;
+
+    # Carpeta donde están los archivos estáticos compilados (copiados en el Dockerfile)
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Soporte para Vue Router / React Router (single page app)
+    location / {
+        try_files $uri /index.html;
+    }
+
+    # Proxy hacia el microservicio de autenticación
+    location /login {
+        proxy_pass http://auth-api:8000;
+    }
+
+    # Proxy hacia el microservicio de TODOs
+    location /todos {
+        proxy_pass http://todos-api:8082;
+    }
+
+    # Proxy hacia Zipkin
+    location /zipkin {
+        proxy_pass http://zipkin:9411/api/v2/spans;
+        proxy_redirect off;
+    }
+}

--- a/log-message-processor/Dockerfile
+++ b/log-message-processor/Dockerfile
@@ -1,0 +1,20 @@
+# Usar Python 3.7 (versión común para este tipo de procesadores)
+FROM python:3.7-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+
+COPY requirements.txt .
+
+#Install code dependecies.
+RUN pip install  -r requirements.txt
+
+COPY . .
+ENV PYTHONUNBUFFERED=1
+CMD [ "python","-u", "main.py" ]

--- a/log-message-processor/main.py
+++ b/log-message-processor/main.py
@@ -2,9 +2,6 @@ import time
 import redis
 import os
 import json
-import requests
-from py_zipkin.zipkin import zipkin_span, ZipkinAttrs, generate_random_64bit_string
-import time
 import random
 
 def log_message(message):
@@ -13,49 +10,29 @@ def log_message(message):
     print('message received after waiting for {}ms: {}'.format(time_delay, message))
 
 if __name__ == '__main__':
-    redis_host = os.environ['REDIS_HOST']
-    redis_port = int(os.environ['REDIS_PORT'])
-    redis_channel = os.environ['REDIS_CHANNEL']
-    zipkin_url = os.environ['ZIPKIN_URL'] if 'ZIPKIN_URL' in os.environ else ''
-    def http_transport(encoded_span):
-        requests.post(
-            zipkin_url,
-            data=encoded_span,
-            headers={'Content-Type': 'application/x-thrift'},
-        )
-
-    pubsub = redis.Redis(host=redis_host, port=redis_port, db=0).pubsub()
-    pubsub.subscribe([redis_channel])
-    for item in pubsub.listen():
-        try:
-            message = json.loads(str(item['data'].decode("utf-8")))
-        except Exception as e:
-            log_message(e)
-            continue
-
-        if not zipkin_url or 'zipkinSpan' not in message:
-            log_message(message)
-            continue
-
-        span_data = message['zipkinSpan']
-        try:
-            with zipkin_span(
-                service_name='log-message-processor',
-                zipkin_attrs=ZipkinAttrs(
-                    trace_id=span_data['_traceId']['value'],
-                    span_id=generate_random_64bit_string(),
-                    parent_span_id=span_data['_spanId'],
-                    is_sampled=span_data['_sampled']['value'],
-                    flags=None
-                ),
-                span_name='save_log',
-                transport_handler=http_transport,
-                sample_rate=100
-            ):
-                log_message(message)
-        except Exception as e:
-            print('did not send data to Zipkin: {}'.format(e))
-            log_message(message)
+    redis_host = os.environ.get('REDIS_HOST', 'redis-todo')
+    redis_port = int(os.environ.get('REDIS_PORT', 6379))
+    redis_channel = os.environ.get('REDIS_CHANNEL', 'log_channel')
+    zipkin_url = os.environ.get('ZIPKIN_URL', 'http://zipkin:9411/api/v2/spans')
+    
+    print(f'Connecting to Redis at {redis_host}:{redis_port}')
+    print(f'Subscribing to channel: {redis_channel}')
+    
+    try:
+        pubsub = redis.Redis(host=redis_host, port=redis_port, db=0).pubsub()
+        pubsub.subscribe([redis_channel])
+        
+        print('Waiting for messages...')
+        for item in pubsub.listen():
+            if item['type'] == 'message':
+                try:
+                    message = json.loads(str(item['data'].decode("utf-8")))
+                    log_message(message)
+                except Exception as e:
+                    print(f'Error processing message: {e}')
+                    continue
+    except Exception as e:
+        print(f'Error connecting to Redis: {e}')
 
 
 

--- a/todos-api/Dockerfile
+++ b/todos-api/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 
 # Variables de entorno (se pueden sobreescribir en docker-compose o docker run -e)
 ENV TODO_API_PORT=8082 \
-    JWT_SECRET=PRFT \
+    JWT_SECRET=myfancysecret \
     REDIS_HOST=redis \
     REDIS_PORT=6379 \
     REDIS_CHANNEL=todos-log \

--- a/todos-api/server.js
+++ b/todos-api/server.js
@@ -30,7 +30,7 @@ const redisClient = require("redis").createClient({
   }        
 });
 const port = process.env.TODO_API_PORT || 8082
-const jwtSecret = process.env.JWT_SECRET || "foo"
+const jwtSecret = process.env.JWT_SECRET || "myfancysecret"
 
 const app = express()
 

--- a/users-api/src/main/resources/application.properties
+++ b/users-api/src/main/resources/application.properties
@@ -2,5 +2,4 @@ jwt.secret=myfancysecret
 server.port=8083
 
 spring.application.name=users-api
-spring.zipkin.baseUrl=http://127.0.0.1:9411/
 spring.sleuth.sampler.percentage=100.0


### PR DESCRIPTION

- Add log-message-processor service to docker-compose
  - depends_on: redis-todo, zipkin
  - environment: REDIS_HOST=redis-todo, REDIS_PORT=6379, REDIS_CHANNEL=log_channel
  - environment: ZIPKIN_URL=http://zipkin:9411/api/v2/spans
  - attach all services to app-network
- Configure todos-api to publish logs to Redis and send traces to Zipkin via env vars
- Fix Python container stdout buffering so logs are visible:
  - set PYTHONUNBUFFERED=1
  - run `python -u main.py` in Dockerfile
- Verified by creating/deleting TODOs and observing messages in log-message-processor
  and service dependencies in Zipkin UI