### PR TITLE
Feature/ci integrations - CI: expand triggers, publish images to GHCR, and add integration smoke tests

### DIFF
--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -49,14 +49,11 @@ jobs:
 
   build-frontend:
     runs-on: ubuntu-latest
-    container:
-      image: node:12-bullseye
+    container: { image: node:8 }
     defaults: { run: { working-directory: frontend } }
     steps:
       - uses: actions/checkout@v4
-      - run: apt-get update && apt-get install -y python2 make g++
-      - run: npm config set python /usr/bin/python2
-      - run: npm ci || npm install
+      - run: npm install
       - run: npm run build
 
   build-log-processor:

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -45,15 +45,13 @@ jobs:
 
   build-frontend:
     runs-on: ubuntu-latest
+    container:
+      image: node:12-buster
     defaults: { run: { working-directory: frontend } }
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with: { node-version: "12" }
-      - uses: actions/setup-python@v5
-        with: { python-version: "2.7" }
-      - run: echo "Using $(python -V) at $(which python)"
-      - run: npm config set python "$(which python)"
+      - run: apt-get update && apt-get install -y python2 make g++
+      - run: npm config set python /usr/bin/python2
       - run: npm install
       - run: npm run build
 

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -46,13 +46,13 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     container:
-      image: node:12-buster
+      image: node:12-bullseye
     defaults: { run: { working-directory: frontend } }
     steps:
       - uses: actions/checkout@v4
       - run: apt-get update && apt-get install -y python2 make g++
       - run: npm config set python /usr/bin/python2
-      - run: npm install
+      - run: npm ci || npm install
       - run: npm run build
 
   build-log-processor:

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -1,0 +1,102 @@
+name: CI & Build
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+  push:
+    branches: [ "develop", "main" ]
+
+jobs:
+  build-auth-api:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: auth-api } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.18" }
+      - run: go test ./...
+      - run: go build -o auth-api
+
+  build-users-api:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: users-api } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - run: mvn -B clean package -DskipTests
+
+  build-todos-api:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: todos-api } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '18' }
+      - run: npm install
+      - run: npm test || echo "no tests"
+
+  build-frontend:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: frontend } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '18' }
+      - run: npm install
+      - run: npm run build
+
+  build-log-processor:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: log-message-processor } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.10' }
+      - run: pip install -r requirements.txt
+      - run: python -m py_compile main.py
+
+  docker:
+    needs: [build-auth-api, build-users-api, build-todos-api, build-frontend, build-log-processor]
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - name: Compute tag
+        id: vars
+        run: echo "TAG=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      - name: Build & push
+        run: |
+          docker build -t ghcr.io/<org>/auth-api:${{ steps.vars.outputs.TAG }} ./auth-api
+          docker build -t ghcr.io/<org>/users-api:${{ steps.vars.outputs.TAG }} ./users-api
+          docker build -t ghcr.io/<org>/todos-api:${{ steps.vars.outputs.TAG }} ./todos-api
+          docker build -t ghcr.io/<org>/frontend:${{ steps.vars.outputs.TAG }} ./frontend
+          docker build -t ghcr.io/<org>/log-processor:${{ steps.vars.outputs.TAG }} ./log-message-processor
+          docker push ghcr.io/<org>/auth-api:${{ steps.vars.outputs.TAG }}
+          docker push ghcr.io/<org>/users-api:${{ steps.vars.outputs.TAG }}
+          docker push ghcr.io/<org>/todos-api:${{ steps.vars.outputs.TAG }}
+          docker push ghcr.io/<org>/frontend:${{ steps.vars.outputs.TAG }}
+          docker push ghcr.io/<org>/log-processor:${{ steps.vars.outputs.TAG }}
+
+  integration:
+    needs: docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose up -d --build
+      - name: Smoke Test
+        run: |
+          TOKEN=$(curl -s -X POST http://localhost:8000/login \
+            -H "Content-Type: application/json" \
+            -d '{"username":"admin","password":"admin"}' | jq -r .accessToken)
+          curl -s -H "Authorization: Bearer $TOKEN" -X POST \
+            http://localhost:8082/todos -d '{"content":"demo"}'
+          curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8082/todos

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -50,8 +50,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: "12" }
-      - run: sudo apt-get update && sudo apt-get install -y python2
-      - run: npm config set python python2
+      - uses: actions/setup-python@v5
+        with: { python-version: "2.7" }
+      - run: echo "Using $(python -V) at $(which python)"
+      - run: npm config set python "$(which python)"
       - run: npm install
       - run: npm run build
 

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -11,6 +11,10 @@ on:
       - "feature/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-auth-api:
     runs-on: ubuntu-latest
@@ -67,50 +71,79 @@ jobs:
 
   docker:
     needs:
-      [
-        build-auth-api,
-        build-users-api,
-        build-todos-api,
-        build-frontend,
-        build-log-processor,
-      ]
+      - build-auth-api
+      - build-users-api
+      - build-todos-api
+      - build-frontend
+      - build-log-processor
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/feature/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Compute tag
         id: vars
-        run: echo "TAG=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-      - name: Build & push
         run: |
-          docker build -t ghcr.io/<org>/auth-api:${{ steps.vars.outputs.TAG }} ./auth-api
-          docker build -t ghcr.io/<org>/users-api:${{ steps.vars.outputs.TAG }} ./users-api
-          docker build -t ghcr.io/<org>/todos-api:${{ steps.vars.outputs.TAG }} ./todos-api
-          docker build -t ghcr.io/<org>/frontend:${{ steps.vars.outputs.TAG }} ./frontend
-          docker build -t ghcr.io/<org>/log-processor:${{ steps.vars.outputs.TAG }} ./log-message-processor
-          docker push ghcr.io/<org>/auth-api:${{ steps.vars.outputs.TAG }}
-          docker push ghcr.io/<org>/users-api:${{ steps.vars.outputs.TAG }}
-          docker push ghcr.io/<org>/todos-api:${{ steps.vars.outputs.TAG }}
-          docker push ghcr.io/<org>/frontend:${{ steps.vars.outputs.TAG }}
-          docker push ghcr.io/<org>/log-processor:${{ steps.vars.outputs.TAG }}
+          BRANCH=${GITHUB_REF_NAME//\//-}
+          echo "TAG=${BRANCH}-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Build & push images
+        run: |
+          OWNER=${GITHUB_REPOSITORY_OWNER,,}
+          TAG='${{ steps.vars.outputs.TAG }}'
+          docker build -t ghcr.io/$OWNER/auth-api:$TAG ./auth-api
+          docker build -t ghcr.io/$OWNER/users-api:$TAG ./users-api
+          docker build -t ghcr.io/$OWNER/todos-api:$TAG ./todos-api
+          docker build -t ghcr.io/$OWNER/frontend:$TAG ./frontend
+          docker build -t ghcr.io/$OWNER/log-processor:$TAG ./log-message-processor
+          docker push ghcr.io/$OWNER/auth-api:$TAG
+          docker push ghcr.io/$OWNER/users-api:$TAG
+          docker push ghcr.io/$OWNER/todos-api:$TAG
+          docker push ghcr.io/$OWNER/frontend:$TAG
+          docker push ghcr.io/$OWNER/log-processor:$TAG
 
   integration:
     needs: docker
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: docker compose up -d --build
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      # Opcional: exportar las imágenes desde GHCR al compose por tag
+      # - name: Login to GHCR (pull)
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compose up
+        run: |
+          docker compose up -d --build
+          # Espera activa hasta que /login responda 200
+          for i in {1..30}; do
+            curl -sf -o /dev/null http://localhost:8000/login && break
+            echo "Esperando auth-api... ($i)"
+            sleep 2
+          done
+
       - name: Smoke Test
         run: |
           TOKEN=$(curl -s -X POST http://localhost:8000/login \
             -H "Content-Type: application/json" \
             -d '{"username":"admin","password":"admin"}' | jq -r .accessToken)
+          echo "TOKEN=${TOKEN:0:10}..."
           curl -s -H "Authorization: Bearer $TOKEN" -X POST \
-            http://localhost:8082/todos -d '{"content":"demo"}'
+            http://localhost:8082/todos -H "Content-Type: application/json" \
+            -d '{"content":"demo"}'
           curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8082/todos

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -2,9 +2,14 @@ name: CI & Build
 
 on:
   pull_request:
-    branches: [ "develop" ]
+    branches:
+      - develop
   push:
-    branches: [ "develop", "main" ]
+    branches:
+      - develop
+      - main
+      - "feature/**" # <-- push a cualquier rama que empiece por feature/
+  workflow_dispatch:
 
 jobs:
   build-auth-api:
@@ -24,8 +29,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '8'
+          distribution: "temurin"
+          java-version: "8"
       - run: mvn -B clean package -DskipTests
 
   build-todos-api:
@@ -34,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '18' }
+        with: { node-version: "18" }
       - run: npm install
       - run: npm test || echo "no tests"
 
@@ -44,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '18' }
+        with: { node-version: "18" }
       - run: npm install
       - run: npm run build
 
@@ -54,13 +59,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: '3.10' }
+        with: { python-version: "3.10" }
       - run: pip install -r requirements.txt
       - run: python -m py_compile main.py
 
   docker:
-    needs: [build-auth-api, build-users-api, build-todos-api, build-frontend, build-log-processor]
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
+    needs:
+      [
+        build-auth-api,
+        build-users-api,
+        build-todos-api,
+        build-frontend,
+        build-log-processor,
+      ]
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/feature/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -49,12 +49,14 @@ jobs:
 
   build-frontend:
     runs-on: ubuntu-latest
-    container: { image: node:8 }
     defaults: { run: { working-directory: frontend } }
     steps:
       - uses: actions/checkout@v4
-      - run: npm install
-      - run: npm run build
+      - name: Build frontend in Node 8 container
+        run: |
+          docker run --rm \
+            -v "$PWD":/app -w /app \
+            node:8 bash -lc "npm install && npm run build"
 
   build-log-processor:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-integrations.yml
+++ b/.github/workflows/ci-integrations.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - develop
       - main
-      - "feature/**" # <-- push a cualquier rama que empiece por feature/
+      - "feature/**"
   workflow_dispatch:
 
 jobs:
@@ -49,7 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: "18" }
+        with: { node-version: "12" }
+      - run: sudo apt-get update && sudo apt-get install -y python2
+      - run: npm config set python python2
       - run: npm install
       - run: npm run build
 


### PR DESCRIPTION

This PR improves our CI pipeline and container publishing workflow.

Changes:
- Run CI on pushes to develop, main, and feature/**; keep PRs targeting develop.
- Grant packages: write permissions to allow publishing to GHCR.
- Keep per-service build jobs:
  - auth-api (Go), users-api (Maven), todos-api (Node), frontend, log-message-processor (Python).
- Frontend: build using a legacy Node 8 environment (via docker) to support node-sass 4.x.
- Add Docker stage:
  - Login to GHCR using GITHUB_TOKEN.
  - Compute image tag as <branch>-<short-sha>.
  - Build and push images to ghcr.io/<owner>/{auth-api,users-api,todos-api,frontend,log-processor}:<tag>.
- Add Integration stage:
  - docker compose up -d --build, wait for auth-api readiness, then run smoke tests:
    - obtain JWT from /login
    - POST/GET todos with the token
  - Install jq for JSON parsing.
